### PR TITLE
Adiciona configuración para desplegar swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "nodemon": "^2.0.12",
         "pg": "^8.6.0",
         "sequelize": "^6.6.5",
+        "swagger-ui-express": "^4.1.6",
         "xhr2": "^0.2.1"
       },
       "devDependencies": {
@@ -1963,7 +1964,6 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.12.tgz",
       "integrity": "sha512-egCTmNZdObdBxUBw6ZNwvZ/xzk24CKRs5K6d+5zbmrMr7rOpPmfPeF6OxM3DDpaRx331CQRFEktn+wrFFfBSOA==",
-      "hasInstallScript": true,
       "dependencies": {
         "chokidar": "^3.2.2",
         "debug": "^3.2.6",
@@ -2803,6 +2803,25 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "3.51.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.51.1.tgz",
+      "integrity": "sha512-df2mEeVgnJp/FcXY3DRh3CsTfvHVTaO6g3FJP/kfwhxfOD1+YTXqBZrOIIsYTPtcRIFBkCAto0NFCxAV4XFRbw=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "dependencies": {
+        "swagger-ui-dist": "^3.18.1"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
       }
     },
     "node_modules/table": {
@@ -5334,6 +5353,19 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.51.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.51.1.tgz",
+      "integrity": "sha512-df2mEeVgnJp/FcXY3DRh3CsTfvHVTaO6g3FJP/kfwhxfOD1+YTXqBZrOIIsYTPtcRIFBkCAto0NFCxAV4XFRbw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nodemon": "^2.0.12",
     "pg": "^8.6.0",
     "sequelize": "^6.6.5",
+    "swagger-ui-express": "^4.1.6",
     "xhr2": "^0.2.1"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -27,5 +27,6 @@ app.use(
 );
 
 app.use('/api/', require('./api/v1/routes'));
+app.use('/docs/', require('./docs'));
 
 module.exports = app;

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const swaggerUi = require('swagger-ui-express');
+
+// Swagger
+const swagger_v1 = require('./v1/swagger.json');
+router.use(['/v1', '/'], swaggerUi.serve, swaggerUi.setup(swagger_v1));
+
+module.exports = router;

--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Open Politica - API",
+    "title": "Open Politica - Congreso - API",
     "version": "0.1.0",
-    "description": "Boilerplate made for Open Politica backend in Node.JS",
+    "description": "API para proyecto Congreso desarrollado para backend de Open Politica in Node.JS",
     "license": {
       "name": "Apache 2.0",
       "url": "https://spdx.org/licenses/Apache-2.0.html"
@@ -16,14 +16,14 @@
   },
   "servers": [
     {
-      "url": "https://api.openpolitica.com",
+      "url": "https://api.congreso.openpolitica.com",
       "description": "Production Server"
     },
     {
-      "url": "https://staging-api.openpolitica.com",
+      "url": "https://api.dev.congreso.openpolitica.com",
       "description": "Staging Server"
     },
-    { "url": "http://localhost:3000", "description": "Development Server" }
+    { "url": "http://localhost:8000", "description": "Development Server" }
   ],
   "paths": {}
 }


### PR DESCRIPTION
Adiciona archivos de configuración para desplegar swagger en la ruta `/docs` y prepara la estructura para las diferentes versiones de la API ubicando los archivos de configuración `swagger.json` en `docs/v1`,  `docs/v2`, ... `docs/vx`