### PR TITLE
Adiciona referencias para social media

### DIFF
--- a/src/models/Congressperson.js
+++ b/src/models/Congressperson.js
@@ -86,6 +86,7 @@ module.exports = function (sequelize, DataTypes) {
     Congressperson.hasMany(SocialNetworkXCongresspersonModel, {
       foreignKey: 'cv_id',
       sourceKey: 'cv_id',
+      as: 'social_networks',
     });
 
     Congressperson.belongsToMany(PoliticalPartyModel, {

--- a/src/models/SocialNetwork_X_Congressperson.js
+++ b/src/models/SocialNetwork_X_Congressperson.js
@@ -22,6 +22,7 @@ module.exports = function (sequelize, DataTypes) {
       last_update_date: DataTypes.DATE,
     },
     {
+      timestamps: false,
       tableName: 'social_network_x_congressperson',
     },
   );
@@ -38,6 +39,7 @@ module.exports = function (sequelize, DataTypes) {
     SocialNetwork_x_Congressperson.belongsTo(SocialNetworkModel, {
       foreignKey: 'social_network_id',
       targetKey: 'social_network_id',
+      as: 'social_network',
     });
   };
 

--- a/src/services/congressperson.service.js
+++ b/src/services/congressperson.service.js
@@ -19,6 +19,8 @@ module.exports = function setupCongresistaService({
   AffiliationModel,
   CongresspersonXParliamentaryGroupModel,
   CongresspersonXPartyModel,
+  SocialNetworkModel,
+  SocialNetworkXCongresspersonModel,
 }) {
   let baseService = new setupBaseService();
 
@@ -147,6 +149,16 @@ module.exports = function setupCongresistaService({
           {
             model: LocationModel,
             as: 'location',
+          },
+          {
+            model: SocialNetworkXCongresspersonModel,
+            as: 'social_networks',
+            include: [
+              {
+                model: SocialNetworkModel,
+                as: 'social_network',
+              },
+            ],
           },
         ],
         order: [


### PR DESCRIPTION
Adiciona información sobre las redes sociales de los congresistas cuando se consulta la ruta:
http://localhost:8000/api/congressperson/nombre-congresista
con la estructura:
```
{
"cv_id": 136033,
"social_network_id": "fe0ae626-85ef-4b11-ac1d-ccf642a4b1be",
"social_network_url": "https://www.facebook.com/congresista",
"last_update_date": null,
"social_network": {
"social_network_id": "fe0ae626-85ef-4b11-ac1d-ccf642a4b1be",
"social_network_name": "Facebook"
}
}
```