### PR TITLE
Consider ID in all tables with one-to-many relationship

### DIFF
--- a/src/models/Affiliation.js
+++ b/src/models/Affiliation.js
@@ -27,7 +27,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Affiliation.removeAttribute('id');
   Affiliation.associate = function ({ CongresspersonModel }) {
     Affiliation.belongsTo(CongresspersonModel, {
       foreignKey: 'dni',

--- a/src/models/Education.js
+++ b/src/models/Education.js
@@ -21,7 +21,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Education.removeAttribute('id');
   Education.associate = function ({ CongresspersonModel }) {
     Education.belongsTo(CongresspersonModel, {
       foreignKey: 'cv_id',

--- a/src/models/Experience.js
+++ b/src/models/Experience.js
@@ -23,7 +23,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Experience.removeAttribute('id');
   Experience.associate = function ({ CongresspersonModel }) {
     Experience.belongsTo(CongresspersonModel, {
       foreignKey: 'cv_id',

--- a/src/models/Goods_Immovable.js
+++ b/src/models/Goods_Immovable.js
@@ -29,7 +29,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Goods_Immovable.removeAttribute('id');
   Goods_Immovable.associate = function ({ CongresspersonModel }) {
     Goods_Immovable.belongsTo(CongresspersonModel, {
       foreignKey: 'cv_id',

--- a/src/models/Goods_Movable.js
+++ b/src/models/Goods_Movable.js
@@ -25,7 +25,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Goods_Movable.removeAttribute('id');
   Goods_Movable.associate = function ({ CongresspersonModel }) {
     Goods_Movable.belongsTo(CongresspersonModel, {
       foreignKey: 'cv_id',

--- a/src/models/Judgment_EC.js
+++ b/src/models/Judgment_EC.js
@@ -21,7 +21,6 @@ module.exports = function (sequelize, DataTypes) {
     },
   );
 
-  Judgment_EC.removeAttribute('id');
   Judgment_EC.associate = function ({ CongresspersonModel }) {
     Judgment_EC.belongsTo(CongresspersonModel, {
       foreignKey: 'cv_id',


### PR DESCRIPTION
Si no se considera, no se obtendrán todas las entradas relacionas con el ID. 
Depende de la actualización en la base de datos con esta información.
Relacionado con: https://github.com/sequelize/sequelize/issues/5193

Closes #33
