### PR TITLE
Fix error search query

### DIFF
--- a/src/helpers/response-builder.js
+++ b/src/helpers/response-builder.js
@@ -6,18 +6,18 @@ class ApiResponseBuilder {
       status: '',
       statusCode: 0,
       data: [],
-      message: ''
-    }
+      message: '',
+    };
     this.pagination = {
-      totalPages : 0,
+      totalPages: 0,
       totalElements: 0,
-      hasNext: false
-    }
+      hasNext: false,
+    };
   }
 
   setSuccessResponse(response) {
     let apiResponse = response.getResponseData();
-    
+
     this.response.status = 'OK';
     this.response.statusCode = apiResponse.responseCode;
     this.response.data = apiResponse.data;
@@ -32,13 +32,13 @@ class ApiResponseBuilder {
   }
 
   setErrorResponse(error) {
-    this.status = 'ERROR';
-    this.statusCode = 500;
-    this.data = [];
-    this.message = error.message;
+    this.response.status = 'ERROR';
+    this.response.statusCode = 500;
+    this.response.data = [];
+    this.response.message = error.message;
 
     if (error instanceof ApiError) {
-      this.statusCode = error.httpStatusCode;
+      this.response.statusCode = error.httpStatusCode;
     }
   }
 

--- a/src/services/base.service.js
+++ b/src/services/base.service.js
@@ -7,7 +7,7 @@ class baseService {
     this.returnData = {
       data: {},
       message: '',
-      responseCode: 200
+      responseCode: 200,
     };
 
     this.pagination = {
@@ -15,8 +15,8 @@ class baseService {
       totalElements: 0,
       hasNext: false,
     };
-    this.paginated = false
-    this.headers = {}
+    this.paginated = false;
+    this.headers = {};
   }
 
   setPaginationResponse(totalPages, totalElements, hasNext) {
@@ -33,7 +33,8 @@ class baseService {
 
   processError(error) {
     console.error('Error: ', error.message);
-    if (process.env.NODE_ENV !== 'production') console.log('StackTrace:\n', error.stack);
+    if (process.env.NODE_ENV !== 'production')
+      console.log('StackTrace:\n', error.stack);
     throw error;
   }
 
@@ -46,12 +47,19 @@ class baseService {
     this.returnData.responseCode = responseCode;
     this.returnData.message = message;
     this.returnData.data = data;
-    return this
+    return this;
   }
 
-  setPaginatedResponse(data, totalPages = 0, totalElements = 0, hasNext = false, message = 'SUCCESS', responseCode = 200) {
-    this.setPaginationResponse(totalPages, totalElements, hasNext)
-    return this.setResponse(data, message, responseCode)
+  setPaginatedResponse(
+    data,
+    totalPages = 0,
+    totalElements = 0,
+    hasNext = false,
+    message = 'SUCCESS',
+    responseCode = 200,
+  ) {
+    this.setPaginationResponse(totalPages, totalElements, hasNext);
+    return this.setResponse(data, message, responseCode);
   }
 
   setHeaders(headers) {


### PR DESCRIPTION
Minor fix to avoid errors when searching with no value `query` like: `/api/search/query=`, which produces errors when in the server and frontend deployment
