### PR TITLE
Adiciona rutas de glosario

### DIFF
--- a/src/api/v1/routes/glossary/glossary.controller.js
+++ b/src/api/v1/routes/glossary/glossary.controller.js
@@ -1,0 +1,28 @@
+//Calling service container
+const serviceContainer = require('../../../../services/service.container');
+const getTermList = async request => {
+  const glossaryService = await serviceContainer('glossary');
+  return await glossaryService.doGetTermList(request.query);
+};
+
+const getTerm = async request => {
+  const glossaryService = await serviceContainer('glossary');
+  return await glossaryService.doGetTerm(request.params);
+};
+
+const getCategoryList = async request => {
+  const glossaryService = await serviceContainer('glossary');
+  return await glossaryService.doGetCategoryList(request.query);
+};
+
+const getCategory = async request => {
+  const glossaryService = await serviceContainer('glossary');
+  return await glossaryService.doGetCategory(request.params);
+};
+
+module.exports = {
+  getTermList,
+  getTerm,
+  getCategoryList,
+  getCategory,
+};

--- a/src/api/v1/routes/glossary/index.js
+++ b/src/api/v1/routes/glossary/index.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+const glossaryController = require('./glossary.controller');
+
+const { controllerHandler } = require('../../../../helpers/express-callback');
+
+router.get('/term', controllerHandler(glossaryController.getTermList));
+
+router.get('/category', controllerHandler(glossaryController.getCategoryList));
+
+router.get(
+  '/term/:slug([a-z]+|[a-z]+(?:-[a-z-]+)*)',
+  controllerHandler(glossaryController.getTerm),
+);
+
+router.get(
+  '/category/:slug([a-z]+|[a-z]+(?:-[a-z-]+)*)',
+  controllerHandler(glossaryController.getCategory),
+);
+
+module.exports = router;

--- a/src/api/v1/routes/index.js
+++ b/src/api/v1/routes/index.js
@@ -10,5 +10,6 @@ router.use('/search', require('./search'));
 router.use('/bill', require('./bill'));
 router.use('/bill-status', require('./bill-status'));
 router.use('/legislature', require('./legislature'));
+router.use('/glossary', require('./glossary'));
 
 module.exports = router;

--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -57,6 +57,10 @@
     {
       "name": "Search",
       "description": "Endpoints to search in database"
+    },
+    {
+      "name": "Glossary",
+      "description": "Endpoints to retrieve glossary entries in database"
     }
   ],
   "paths": {
@@ -741,6 +745,108 @@
               "type": "integer"
             },
             "required": false
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+
+    "/api/glossary/term": {
+      "get": {
+        "tags": ["Glossary"],
+        "summary": "Returns information about glossary terms. If a query parameter is not defined, returns the complete list of terms. Otherwise return the information about a specific term. Accepts 'slug' as a parameter.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "slug",
+            "description": "Identificator of a specific glossary term through its slug",
+            "schema": {
+              "type": "text"
+            },
+            "required": false
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+
+    "/api/glossary/term/{slug}": {
+      "get": {
+        "tags": ["Glossary"],
+        "summary": "Returns information about a specific glossary term using the slug value as the identificator.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "pattern": "[a-z]|[a-z]+(?:-[a-z-]+)*",
+            "description": "URL-friendly name identificator of a specific glossary term.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+
+    "/api/glossary/category": {
+      "get": {
+        "tags": ["Glossary"],
+        "summary": "Returns information about glossary categories. If a query parameter is not defined, returns the complete list of categories. Otherwise return the information about a specific categories. Accepts 'slug' as a parameter.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "slug",
+            "description": "Identificator of a specific glossary category through its slug",
+            "schema": {
+              "type": "text"
+            },
+            "required": false
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+
+    "/api/glossary/category/{slug}": {
+      "get": {
+        "tags": ["Glossary"],
+        "summary": "Returns information about a specific glossary category using the slug value as the identificator.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "pattern": "[a-z]|[a-z]+(?:-[a-z-]+)*",
+            "description": "URL-friendly name identificator of a specific glossary category.",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
           }
         ],
         "consumes": ["application/json"],

--- a/src/models/Category.js
+++ b/src/models/Category.js
@@ -1,0 +1,27 @@
+module.exports = function (sequelize, DataTypes) {
+  const Category = sequelize.define(
+    'CategoryModel',
+    {
+      category_id: {
+        type: DataTypes.TEXT,
+        primaryKey: true,
+      },
+      category_name: DataTypes.TEXT,
+      category_description: DataTypes.DATE,
+    },
+    {
+      tableName: 'category',
+      timestamps: false,
+    },
+  );
+
+  Category.associate = function ({ GlossaryModel }) {
+    Category.hasMany(GlossaryModel, {
+      foreignKey: 'category_id',
+      sourceKey: 'category_id',
+      as: 'terms',
+    });
+  };
+
+  return Category;
+};

--- a/src/models/Glossary.js
+++ b/src/models/Glossary.js
@@ -1,0 +1,37 @@
+module.exports = function (sequelize, DataTypes) {
+  const Glossary = sequelize.define(
+    'GlossaryModel',
+    {
+      glossary_id: {
+        type: DataTypes.TEXT,
+        primaryKey: true,
+      },
+      glossary_name: DataTypes.TEXT,
+      category_id: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        references: {
+          model: 'CategoryModel',
+          key: 'category_id',
+        },
+      },
+      glossary_description: DataTypes.DATE,
+      glossary_source: DataTypes.TEXT,
+      glossary_source_url: DataTypes.TEXT,
+    },
+    {
+      tableName: 'glossary',
+      timestamps: false,
+    },
+  );
+
+  Glossary.associate = function ({ CategoryModel }) {
+    Glossary.belongsTo(CategoryModel, {
+      foreignKey: 'category_id',
+      targetKey: 'category_id',
+      as: 'category',
+    });
+  };
+
+  return Glossary;
+};

--- a/src/services/glossary.service.js
+++ b/src/services/glossary.service.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const setupBaseService = require('./base.service');
+const { Sequelize } = require('sequelize');
+
+module.exports = function setupGlossaryService({
+  GlossaryModel,
+  CategoryModel,
+}) {
+  let baseService = new setupBaseService();
+
+  async function doGetTermList({ slug }) {
+    try {
+      let where = slug ? { glossary_id: slug } : {};
+      const termList = await GlossaryModel.findAll({
+        where,
+        include: [
+          {
+            model: CategoryModel,
+            as: 'category',
+            required: false,
+          },
+        ],
+        order: [['glossary_id', 'ASC']],
+      });
+      return baseService.setResponse(termList);
+    } catch (error) {
+      baseService.throwErrorResponse(error);
+    }
+  }
+
+  async function doGetTerm({ slug }) {
+    try {
+      const where = slug ? { glossary_id: slug } : {};
+      const termDetail = await GlossaryModel.findOne({
+        where,
+        include: [
+          {
+            model: CategoryModel,
+            as: 'category',
+            separate: false,
+          },
+        ],
+      });
+      return baseService.setResponse(termDetail);
+    } catch (error) {
+      baseService.throwErrorResponse(error);
+    }
+  }
+
+  async function doGetCategoryList({ slug }) {
+    try {
+      let where = slug ? { category_id: slug } : {};
+      const categoryList = await CategoryModel.findAll({
+        where,
+        attributes: {
+          include: [
+            [
+              Sequelize.fn('COUNT', Sequelize.col('terms.glossary_id')),
+              'count',
+            ],
+          ],
+        },
+        include: [
+          {
+            model: GlossaryModel,
+            as: 'terms',
+            attributes: [],
+            required: false,
+          },
+        ],
+        group: ['CategoryModel.category_id'],
+        order: [['category_id', 'ASC']],
+      });
+      return baseService.setResponse(categoryList);
+    } catch (error) {
+      baseService.throwErrorResponse(error);
+    }
+  }
+
+  async function doGetCategory({ slug }) {
+    try {
+      const where = slug ? { category_id: slug } : {};
+      const categoryDetail = await CategoryModel.findOne({
+        where,
+        include: [
+          {
+            model: GlossaryModel,
+            as: 'terms',
+            separate: true,
+          },
+        ],
+      });
+      return baseService.setResponse(categoryDetail);
+    } catch (error) {
+      baseService.throwErrorResponse(error);
+    }
+  }
+
+  return {
+    doGetTermList,
+    doGetTerm,
+    doGetCategoryList,
+    doGetCategory,
+  };
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -10,6 +10,7 @@ const setupSearchService = require('./search.service');
 const setupBillService = require('./bill.service');
 const setupLegislatureService = require('./legislature.service');
 const setupBillStatusService = require('./bill-status.service');
+const setupGlossaryService = require('./glossary.service');
 
 module.exports = async function () {
   const congresspersonService = setupCongresspersonService(models);
@@ -20,6 +21,7 @@ module.exports = async function () {
   const billService = setupBillService(models);
   const legislatureService = setupLegislatureService(models);
   const billStatusService = setupBillStatusService(models);
+  const glossaryService = setupGlossaryService(models);
 
   return {
     congresspersonService,
@@ -30,5 +32,6 @@ module.exports = async function () {
     billService,
     billStatusService,
     legislatureService,
+    glossaryService,
   };
 };

--- a/src/services/service.container.js
+++ b/src/services/service.container.js
@@ -26,5 +26,7 @@ module.exports = async function serviceContainer(serviceName) {
       return services.legislatureService;
     case 'search':
       return services.searchService;
+    case 'glossary':
+      return services.glossaryService;
   }
 };


### PR DESCRIPTION
Adiciona las rutas para obtener la información del glosario desde la base de datos:

Probar con:
- `/api/glossary/term`: para lista de términos del glosario
- `/api/glossary/term/[slug]`: para un término en específico
- `/api/glossary/category`: para lista de categorías en el glosario
- `/api/glossary/category/[slug]`: para una categoría en específico

closes #66 