### PR TITLE
Adiciona filtro para obtener los proyectos de ley presentados en fecha específica

### DIFF
--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -687,6 +687,15 @@
               "type": "string"
             },
             "required": false
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "description": "Presentation's date of the bill",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
         "responses": {

--- a/src/services/bill.service.js
+++ b/src/services/bill.service.js
@@ -26,6 +26,7 @@ module.exports = function setupBillService({
     billStatus,
     committee,
     author,
+    date,
   }) {
     try {
       let pageNumber = page ? (page == 0 ? 1 : page) : 1;
@@ -104,6 +105,12 @@ module.exports = function setupBillService({
             Op.eq,
             legislature,
           ),
+        );
+      }
+
+      if (date) {
+        where_and.push(
+          sequelize.where(sequelize.col('presentation_date'), Op.eq, date),
         );
       }
 


### PR DESCRIPTION
Agregando la clave `date` se obtiene solamente los proyectos presentados en esa fecha. Ej `api/bill?date=2022-03-18` solo devolverá los proyectos que han sido presentados la fecha 2022-03-18.

closes #69 