### PR TITLE
Show social network name in bill query

### DIFF
--- a/src/services/bill.service.js
+++ b/src/services/bill.service.js
@@ -243,6 +243,7 @@ module.exports = function setupBillService({
                   {
                     model: SocialNetworkXCongresspersonModel,
                     as: 'social_networks',
+                    separate: true,
                     include: [
                       {
                         model: SocialNetworkModel,


### PR DESCRIPTION
En el PR anterior no se muestra el nombre la red social.

```
"social_networks": [
{
"cv_id": 135035,
"social_network_id": "432b0dd4-2a6e-4c6c-9995-bf8755d4925d",
"social_network_url": "https://twitter.com/adrianatudelag",
"social_network_username": "adrianatudelag",
"social_network_account_type": null,
"social_network_is_verified": false,
"social_network_age": "2013-02-01",
"last_update_date": null,
"social_network": {
"social_network_id": "432b0dd4-2a6e-4c6c-9995-bf8755d4925d"
}
},
``` 
Es necesario hacer una consulta separada para obtener este campo.
