### PR TITLE
Adding enable query param for bills

### DIFF
--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -696,6 +696,16 @@
               "type": "string"
             },
             "required": false
+          },
+          {
+            "in": "query",
+            "name": "enable",
+            "description": "Additional fields enabled in response",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "example": "social_network"
           }
         ],
         "responses": {


### PR DESCRIPTION
The bills list endpoint should have a toggle to enable some fields in the response.
`&enable=social_network`

For now only 1 toggle is enabled but this can be modified as we need.