### PR TITLE
Adiciona endpoint de conteo de PL como estadísticas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
+        "dayjs": "^1.11.3",
         "debug": "^4.3.2",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
@@ -678,6 +679,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -3795,6 +3801,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+    },
+    "dayjs": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
+      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
     },
     "debug": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/openpolitica/open-tracker-backend#readme",
   "dependencies": {
     "cors": "^2.8.5",
+    "dayjs": "^1.11.3",
     "debug": "^4.3.2",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",

--- a/src/api/v1/routes/bill/bill.controller.js
+++ b/src/api/v1/routes/bill/bill.controller.js
@@ -11,7 +11,13 @@ const getBill = async request => {
   return await billService.doGetBill(request.params);
 };
 
+const getBillStatistics = async request => {
+  const billService = await serviceContainer('bill');
+  return await billService.doGetBillStatistics(request.query);
+};
+
 module.exports = {
   getBillList,
   getBill,
+  getBillStatistics,
 };

--- a/src/api/v1/routes/bill/index.js
+++ b/src/api/v1/routes/bill/index.js
@@ -12,5 +12,6 @@ router.get(
   '/:id([0-9]{4}-[0-9]{4}-[0-9]{5})',
   controllerHandler(billController.getBill),
 );
+router.get('/statistics', controllerHandler(billController.getBillStatistics));
 
 module.exports = router;

--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -745,13 +745,13 @@
     "/api/bill/statistics": {
       "get": {
         "tags": ["Bill"],
-        "summary": "Returns statistics and a counter of bills based on the requested date(s).",
+        "summary": "Returns statistics about bills information based on required date(s).",
         "parameters": [
           {
             "in": "query",
             "name": "startdate",
-            "description": "Starting date to count for bills statistics.",
-            "pattern": "YYYYMMDD",
+            "description": "Starting date to count for bills statistics. Uses the YYYY-MM-DD pattern.",
+            "pattern": "YYYY-MM-DD",
             "schema": {
               "type": "string"
             },
@@ -760,8 +760,8 @@
           {
             "in": "query",
             "name": "enddate",
-            "description": "Ending date to count for bills statistics. If not provided, uses the time when the query is executed",
-            "pattern": "YYYYMMDD",
+            "description": "Ending date to count for bills statistics. Uses the YYYY-MM-DD pattern. If not provided, uses the time when the query is executed",
+            "pattern": "YYYY-MM-DD",
             "schema": {
               "type": "string"
             },

--- a/src/docs/v1/swagger.json
+++ b/src/docs/v1/swagger.json
@@ -742,6 +742,51 @@
       }
     },
 
+    "/api/bill/statistics": {
+      "get": {
+        "tags": ["Bill"],
+        "summary": "Returns statistics and a counter of bills based on the requested date(s).",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "startdate",
+            "description": "Starting date to count for bills statistics.",
+            "pattern": "YYYYMMDD",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "enddate",
+            "description": "Ending date to count for bills statistics. If not provided, uses the time when the query is executed",
+            "pattern": "YYYYMMDD",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "showlist",
+            "description": "Boolean value that represents if the user want to get the bill list that originated the output numbers. If not provided, uses false as default.",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": false
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+
     "/api/search": {
       "get": {
         "tags": ["Search"],

--- a/src/services/bill.service.js
+++ b/src/services/bill.service.js
@@ -345,7 +345,7 @@ module.exports = function setupBillService({
 
   async function doGetBillStatistics({ startdate, enddate, showlist = false }) {
     try {
-      const dateFormat = 'YYYYMMDD';
+      const dateFormat = 'YYYY-MM-DD';
       const start = parseStringWithFormat(startdate, dateFormat);
       const end = enddate
         ? parseStringWithFormat(enddate, dateFormat)

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -1,0 +1,21 @@
+const dayjs = require('dayjs');
+const customParseFormat = require('dayjs/plugin/customParseFormat');
+const ApiError = require('./ApiError');
+dayjs.extend(customParseFormat);
+
+function parseStringWithFormat(dateStr, format) {
+  const parsedDate = dayjs(dateStr, format, true);
+  if (!parsedDate.isValid()) {
+    throw new ApiError('Unsopported Date format', 400);
+  }
+  return parsedDate.toDate();
+}
+
+function parseDateToFormat(date, output_format) {
+  return dayjs(date).format(output_format);
+}
+
+module.exports = {
+  parseStringWithFormat,
+  parseDateToFormat,
+};


### PR DESCRIPTION
Adiciona una nueva ruta `/bills/statistics` para obtener diferentes estadísticas que se necesiten sobre los bills. Hace uso de `startdate`, `enddate` y `showlist` como parámetros. Las fechas usan el formato `YYYY-MM-DD`.
startdate: Fecha de Inicio. Requerido
enddate: Fecha de Fin. Si no es provisto, usa hoy por defecto
showlist: Parámetro adicional para obtener la lista de PLs obtenidos por el query.

<details>
  <summary>Ejemplo de Resultado del endpoint</summary>

`/api/bill/statistics?startdate=2022-05-31&enddate=2022-05-31`

```json
{
    "status": "OK",
    "statusCode": 200,
    "data": {
      "total": 4,
      "declarative": 2,
      "start_date": "31/05/2022",
      "end_date": "31/05/2022"
    },
    "message": "SUCCESS"
}
```
</details>

Adicionalmente, se está agregando la dependencia [dayjs](https://day.js.org/) usada para el manejo y formateo de fechas.

closes #78 